### PR TITLE
implement ComputerWindow component

### DIFF
--- a/src/components/computer-window.js
+++ b/src/components/computer-window.js
@@ -1,0 +1,17 @@
+import styles from "@/styles/ComputerWindow.module.css"
+
+export default function ComputerWindow({ width, height, topbarColor }) {
+	return (
+		<>
+			<div className={styles.container} style={{width, height}}>
+				<div className={styles.topbar} style={{"background-color": topbarColor}}>
+					<ul>
+						<li className={`${styles.topbarButtons} ${styles.topbarRedButton}`}></li>
+						<li className={`${styles.topbarButtons} ${styles.topbarYellowButton}`}></li>
+						<li className={`${styles.topbarButtons} ${styles.topbarGreenButton}`}></li>
+					</ul>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/src/components/computer-window.js
+++ b/src/components/computer-window.js
@@ -1,6 +1,6 @@
 import styles from "@/styles/ComputerWindow.module.css"
 
-export default function ComputerWindow({ width, height, topbarColor }) {
+export default function ComputerWindow({ width, height, topbarColor = "#65C7CC" }) {
 	return (
 		<>
 			<div className={styles.container} style={{width, height}}>

--- a/src/styles/ComputerWindow.module.css
+++ b/src/styles/ComputerWindow.module.css
@@ -1,0 +1,36 @@
+.topbarButtons {
+  border-radius: 100%;
+  height: 0.5rem;
+  list-style: none;
+  position: absolute;
+  top: 0.75rem;
+  width: 0.5rem;
+}
+
+.container {
+  background-color: white;
+  border-radius: 1rem;
+  display: flex;
+  overflow: hidden;
+}
+
+.topbar {
+  height: 2rem;
+  position: relative;
+  width: 100%;
+}
+
+.topbarGreenButton {
+  background-color: lime;
+  left: 2.5rem;
+}
+
+.topbarRedButton {
+  background-color: red;
+  left: 0.5rem;
+}
+
+.topbarYellowButton {
+  background-color: yellow;
+  left: 1.5rem;
+}


### PR DESCRIPTION
## Status:

:rocket: Ready

<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

Creates the ComputerWindow component that accepts props for width, height, and the color of the top part of the window.


<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

Addresses #237 

## Screenshots

<img width="611" alt="image" src="https://github.com/IllinoisWCS/IllinoisWCS.github.io/assets/43323130/a7892fd1-4b10-4f1f-8d01-d7de97ee1228">


<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
