### PR TITLE
Fix dynamic sizing of ComputerWindow component

### DIFF
--- a/src/components/computer-window.js
+++ b/src/components/computer-window.js
@@ -6,7 +6,7 @@ export default function ComputerWindow({children, topbarColor = "#65C7CC"}) {
       <div className={styles.container}>
         <div
           className={styles.topbar}
-          style={{"background-color": topbarColor}}
+          style={{backgroundColor: topbarColor}}
         >
           <ul>
             <li

--- a/src/styles/ComputerWindow.module.css
+++ b/src/styles/ComputerWindow.module.css
@@ -12,7 +12,9 @@
   border-radius: 1rem;
   display: flex;
   flex-direction: column;
+  height: fit-content;
   overflow: hidden;
+  width: fit-content;
 }
 
 .topbar {


### PR DESCRIPTION
## Status:

:rocket: Ready

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

Fixes an issue where the ComputerWindow component would take up the whole width of its container instead of the width of its children elements.

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

## Screenshots

Old:
<img width="1268" alt="Screenshot 2023-10-25 142005" src="https://github.com/IllinoisWCS/IllinoisWCS.github.io/assets/43323130/45271018-4dfc-4ea9-90d1-829c41c06dea">

New:
<img width="223" alt="Screenshot 2023-10-25 142036" src="https://github.com/IllinoisWCS/IllinoisWCS.github.io/assets/43323130/2fc55af7-28ed-445e-883b-09d08cc1abf1">

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
