### PR TITLE
add collapsable text component

### DIFF
--- a/public/assets/design-vectors/chevron.svg
+++ b/public/assets/design-vectors/chevron.svg
@@ -1,0 +1,3 @@
+<svg width="145" height="298" viewBox="0 0 145 298" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 9L128 148.75L10 289" stroke="#21636C" stroke-width="25"/>
+</svg>

--- a/src/components/CollapsableTextComponent.js
+++ b/src/components/CollapsableTextComponent.js
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import styles from "@/styles/CollapsableTextComponent.module.css";
+
+export default function CollapsableTextComponent({
+  title,
+  children,
+  link="",
+  className,
+}) {
+    const [collapsed, setCollapsed] = useState(true);
+
+  return (
+    <>
+      <div className={`${styles.container} ${className}`}>
+        <button className={`${styles.titleButton}`} onClick={() => {setCollapsed(!collapsed)}}>
+            <h4 className={`${styles.title}`}> {title} </h4>
+
+            {
+                collapsed ? 
+                <img
+                className={`${styles.chevronDown}`}
+                src="assets/design-vectors/chevron.svg" width="20" height="20" 
+                /> 
+                :
+                <img
+                    className={`${styles.chevronUp}`}
+                    src="assets/design-vectors/chevron.svg" width="20" height="20" 
+                />
+            }   
+        </button>
+
+        {
+                collapsed ? <div></div> :
+                    <div className={`${styles.content}`}> 
+                        <p className={`${styles.description}`}> {children} </p>
+                        {link == "" ? <p></p> :<p> <a className={`${styles.link}`} href={link} target="_blank"> &rarr; link to website </a></p>}
+                    </div>
+        }
+      </div>
+    </>
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,6 +8,7 @@ import UpcomingEventsSection from "@/components/UpcomingEventsSection";
 import AboutUsSection from "@/components/AboutUsSection";
 import SponsorsSection from "@/components/SponsorsSection";
 import OpenOffice from "./openoffice";
+import CollapsableTextComponent from "@/components/CollapsableTextComponent";
 
 const inter = Inter({subsets: ["latin"]});
 

--- a/src/styles/CollapsableTextComponent.module.css
+++ b/src/styles/CollapsableTextComponent.module.css
@@ -1,0 +1,62 @@
+.container {
+    border-width: 0.4rem;
+    border-style: solid;
+    border-color: white;
+    background-color: #d2ecfd;
+    border-radius: 2rem;
+    display: flex;
+    flex-direction: column;
+    height: fit-content;
+    overflow: hidden;
+    width: 26rem;
+}
+
+.content {
+    padding-top: 1rem;
+    padding-left: 2rem;
+    padding-bottom: 1rem;
+    padding-right: 2rem;
+}
+
+.chevronUp {
+    transform: rotate(270deg) scale(1.4);
+    margin-right: 2rem;
+    margin-top: 1.1rem
+}
+
+.chevronDown {
+    transform: rotate(90deg) scale(1.4);
+    margin-right: 2rem;
+    margin-top: 1.1rem
+}
+
+.title {
+    padding-left: 1rem;
+    padding-top: 0.8rem;
+    padding-bottom:0.3rem;
+}
+
+.titleButton {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    background-color: transparent;
+    border: none;
+}
+
+.active, .container:hover {
+    border-color: #21636c;
+}
+
+.description {
+    font-size: 1rem;
+    margin-bottom: 0.3rem;
+}
+
+.link {
+    font-size: 1rem;
+}
+
+.active, .link:hover {
+    color: #ffffff;
+}


### PR DESCRIPTION
## Status: :rocket:

## Description

Add a reusable collapsable text component that can be used for the resources page. 

Parameters: 
* title
* [optional] link
* [optional] classname
* description as children

Sample usage:

```
<CollapsableTextComponent title="Counseling Center" link="https://google.com"> The UIUC Counseling Center is committed to providing a range of resources intended to help students develop improved coping skills to address emotional, interpersonal, and academic concerns </CollapsableTextComponent>
```

Addresses #291 

## Screenshots

<img width="430" alt="image" src="https://github.com/IllinoisWCS/IllinoisWCS.github.io/assets/57074850/f46db180-5639-4524-9a69-48424081cdf3">

<img width="430" alt="image" src="https://github.com/IllinoisWCS/IllinoisWCS.github.io/assets/57074850/ef189068-bcea-419c-8a97-3970bc98a50a">
