### PR TITLE
display calendar in prod build

### DIFF
--- a/src/data/openOffice.json
+++ b/src/data/openOffice.json
@@ -5,33 +5,70 @@
         "heading": "Monday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Kavya Puranam", "Neha Vardhaman"],
-            "committees": ["Elaina Xiao"]
+            "time": "2:00-2:30",
+            "officers": [
+              "Saloni Vaishnav",
+              "Firmiana Wang",
+              "Elaina Xiao"
+            ],
+            "committees": [
+              "Becky Blake",
+              "Rachel Chen",
+              "Skyla Jin"
+            ]
           },
           {
-            "time": "2:30 - 3:00",
-            "officers": ["Kavya Puranam", "Neha Vardhaman"],
-            "committees": ["Elaina Xiao"]
+            "time": "2:30-3:00",
+            "officers": [
+              "Saloni Vaishnav",
+              "Firmiana Wang",
+              "Elaina Xiao"
+            ],
+            "committees": [
+              "Becky Blake",
+              "Alisha Virani"
+            ]
           },
           {
             "time": "3:00-3:30",
-            "officers": ["Kavya Puranam"],
-            "committees": ["Sami Duby", "Jacob Edley", "Aditi Kumar"]
+            "officers": [
+              "Firmiana Wang",
+              "Aditi Prasad",
+              "Elaina Xiao"
+            ],
+            "committees": [
+              "Brillina Wang",
+              "Aditi Kumar",
+              "Alisha Virani"
+            ]
           },
           {
             "time": "3:30-4:00",
-            "officers": ["Kavya Puranam", "Anushri Mittal"],
-            "committees": ["Jacob Edley"]
+            "officers": [
+              "Firmiana Wang",
+              "Aditi Prasad",
+              "Elaina Xiao"
+            ],
+            "committees": [
+              "Fiona Hu",
+              "Jia Gill",
+              "Helena Ilic"
+            ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Sailaja Nallacheruvu", "Riya Jain", "Divya Koya"],
-            "committees": ["Saloni Vaishnav"]
+            "time": "4:00-4:30",
+            "officers": [
+              "Simone Schwaighart",
+              "Aditi Prasad"
+            ],
+            "committees": []
           },
           {
-            "time": "4:30 - 5:00",
-            "officers": ["Sailaja Nallacheruvu", "Riya Jain", "Divya Koya"],
+            "time": "4:30-5:00",
+            "officers": [
+              "Simone Schwaighart",
+              "Aditi Prasad"
+            ],
             "committees": []
           }
         ]
@@ -40,34 +77,69 @@
         "heading": "Tuesday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Ananya Rajagopal", "Garima Sharma"],
-            "committees": ["Grace Ren", "Brillina Wang"]
+            "time": "2:00-2:30",
+            "officers": [
+              "Saloni Vaishnav",
+              "Kathryn Lee"
+            ],
+            "committees": [
+              "Vani Ramesh",
+              "Abby Gillham"
+            ]
           },
           {
-            "time": "2:30 - 3:00",
-            "officers": ["Ananya Rajagopal", "Shreya Deshpande", "Kalika Raje"],
-            "committees": ["Shagun Khare", "Grace Ren", "Brillina Wang"]
+            "time": "2:30-3:00",
+            "officers": [
+              "Saloni Vaishnav",
+              "Kathryn Lee"
+            ],
+            "committees": [
+              "Vani Ramesh",
+              "Abby Gillham",
+              "Madison Lee"
+            ]
           },
           {
-            "time": "3:00 - 3:30",
-            "officers": ["Riya Jain", "Shreya Deshpande", "Kalika Raje"],
-            "committees": ["Shagun Khare", "Anagha Shenoy"]
+            "time": "3:00-3:30",
+            "officers": [
+              "Tia Kashyap",
+              "Kathryn Lee"
+            ],
+            "committees": [
+              "Prisha Thoguluva",
+              "Shivi Narang",
+              "Madison Lee"
+            ]
           },
           {
-            "time": "3:30 - 4:00",
-            "officers": ["Riya Jain", "Shreya Vinjamuri"],
-            "committees": ["Anagha Shenoy"]
+            "time": "3:30-4:00",
+            "officers": [
+              "Tia Kashyap",
+              "Kathryn Lee"
+            ],
+            "committees": [
+              "Prisha Thoguluva"
+            ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Shreya Vinjamuri", "Jillian Nylund"],
-            "committees": ["Annapoorna Narayan", "Karen Gao", "Sarena Yang"]
+            "time": "4:00-4:30",
+            "officers": [
+              "Kalika Raje",
+              "Tia Kashyap"
+            ],
+            "committees": [
+              "Julia Koite"
+            ]
           },
           {
-            "time": "4:30 - 5:00",
-            "officers": ["Shreya Vinjamuri", "Jillian Nylund"],
-            "committees": ["Annapoorna Narayan", "Karen Gao", "Sarena Yang"]
+            "time": "4:30-5:00",
+            "officers": [
+              "Kalika Raje",
+              "Tia Kashyap"
+            ],
+            "committees": [
+              "Julia Koite"
+            ]
           }
         ]
       },
@@ -75,38 +147,72 @@
         "heading": "Wednesday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Jillian Nylund"],
-            "committees": ["Navya Ahuja"]
-          },
-          {
-            "time": "2:30 - 3:00",
-            "officers": ["Jillian Nylund", "Sailaja Nallacheruvu"],
-            "committees": ["Navya Ahuja"]
-          },
-          {
-            "time": "3:00 - 3:30",
-            "officers": ["Sailaja Nallacheruvu"],
-            "committees": ["Shriya Dave", "Anisha Nagaraj", "Tia Kashyap"]
-          },
-          {
-            "time": "3:30 - 4:00",
+            "time": "2:00-2:30",
             "officers": [
-              "Akshata Tiwari",
-              "Shreya Deshpande",
-              "Anushri Mittal"
+              "Karen Gao",
+              "Annapoorna Narayan",
+              "Shagun Khare"
             ],
-            "committees": ["Shriya Dave", "Anisha Nagaraj", "Tia Kashyap"]
+            "committees": [
+              "Ashlee Tran"
+            ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Shreya Deshpande", "Kalika Raje", "Divya Koya"],
-            "committees": ["Simone Schwaighart", "Hetvi Patel"]
+            "time": "2:30-3:00",
+            "officers": [
+              "Karen Gao",
+              "Annapoorna Narayan",
+              "Shagun Khare"
+            ],
+            "committees": [
+              "Madhumita Narayan",
+              "Ashlee Tran"
+            ]
           },
           {
-            "time": "4:30 - 5:00",
-            "officers": ["Kalika Raje", "Shreya Vinjamuri", "Divya Koya"],
-            "committees": ["Simone Schwaighart", "Hetvi Patel"]
+            "time": "3:00-3:30",
+            "officers": [
+              "Emma Maxwell",
+              "Annapoorna Narayan"
+            ],
+            "committees": [
+              "Madhumita Narayan"
+            ]
+          },
+          {
+            "time": "3:30-4:00",
+            "officers": [
+              "Emma Maxwell",
+              "Shreya Deshpande",
+              "Annapoorna Narayan"
+            ],
+            "committees": [
+              "Sriya Gottiparthi",
+              "Siya Choudhary"
+            ]
+          },
+          {
+            "time": "4:00-4:30",
+            "officers": [
+              "Emma Maxwell",
+              "Simone Schwaighart",
+              "Shreya Deshpande"
+            ],
+            "committees": [
+              "Kashvi Panjolia"
+            ]
+          },
+          {
+            "time": "4:30-5:00",
+            "officers": [
+              "Emma Maxwell",
+              "Simone Schwaighart"
+            ],
+            "committees": [
+              "Kashvi Panjolia",
+              "Nicole Hu",
+              "Sailaja Nallacheruvu"
+            ]
           }
         ]
       },
@@ -114,34 +220,71 @@
         "heading": "Thursday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Ananya Rajagopal", "Garima Sharma", "Anushri Mittal"],
-            "committees": ["Madhumita Narayan"]
+            "time": "2:00-2:30",
+            "officers": [
+              "Shriya Dave"
+            ],
+            "committees": [
+              "Hiral Palakurty",
+              "Sahana Sankar"
+            ]
           },
           {
-            "time": "2:30 - 3:00",
-            "officers": ["Ananya Rajagopal", "Garima Sharma", "Anushri Mittal"],
-            "committees": ["Madhumita Narayan", "Srushti Nerkar"]
+            "time": "2:30-3:00",
+            "officers": [
+              "Shriya Dave"
+            ],
+            "committees": [
+              "Hiral Palakurty",
+              "Natalie DuShane"
+            ]
           },
           {
-            "time": "3:00 - 3:30",
-            "officers": ["Garima Sharma"],
-            "committees": ["Mahima Agrawal", "Srushti Nerkar"]
+            "time": "3:00-3:30",
+            "officers": [
+              "Kavya Puranam",
+              "Shriya Dave"
+            ],
+            "committees": [
+              "Shivi Narang",
+              "Natalie DuShane"
+            ]
           },
           {
-            "time": "3:30 - 4:00",
-            "officers": ["Akshata Tiwari"],
-            "committees": ["Prisha Singh", "Aditi Prasad", "Mahima Agrawal"]
+            "time": "3:30-4:00",
+            "officers": [
+              "Kavya Puranam",
+              "Shreya Deshpande",
+              "Shriya Dave"
+            ],
+            "committees": [
+              "Lauren Peng",
+              "Tanishka Suman",
+              "Vaani Rometra"
+            ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Akshata Tiwari"],
-            "committees": ["Prisha Singh", "Aditi Prasad", "Thea Surya"]
+            "time": "4:00-4:30",
+            "officers": [
+              "Kavya Puranam",
+              "Kalika Raje",
+              "Shreya Deshpande"
+            ],
+            "committees": [
+              "Sofia Stoica",
+              "Vaani Rometra"
+            ]
           },
           {
-            "time": "4:30 - 5:00",
-            "officers": ["Akshata Tiwari"],
-            "committees": []
+            "time": "4:30-5:00",
+            "officers": [
+              "Kavya Puranam",
+              "Kalika Raje"
+            ],
+            "committees": [
+              "Sofia Stoica",
+              "Anshi Mathur"
+            ]
           }
         ]
       },
@@ -149,77 +292,136 @@
         "heading": "Friday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Neha Vardhaman", "Akriti Arora", "Twinkle Yeruva"],
-            "committees": ["Helena Ilic"]
-          },
-          {
-            "time": "2:30 - 3:00",
-            "officers": ["Neha Vardhaman", "Akriti Arora", "Twinkle Yeruva"],
-            "committees": ["Michelle Sun", "Sanjana Settipalli", "Helena Ilic"]
-          },
-          {
-            "time": "3:00 - 3:30",
-            "officers": ["Aarthi Balaji", "Akriti Arora", "Twinkle Yeruva"],
+            "time": "2:00-2:30",
+            "officers": [
+              "Shagun Khare",
+              "Karen Gao",
+              "Shreya Vinjamuri"
+            ],
             "committees": [
-              "Michelle Sun",
-              "Ashika Koripelly",
-              "Sanjana Settipalli"
+              "Megan Tran",
+              "Sophia Moylan"
             ]
           },
           {
-            "time": "3:30 - 4:00",
-            "officers": ["Aarthi Balaji", "Akriti Arora", "Twinkle Yeruva"],
-            "committees": ["Maya Ashok", "Ashika Koripelly", "Prisha Thogulva"]
+            "time": "2:30-3:00",
+            "officers": [
+              "Shagun Khare",
+              "Karen Gao",
+              "Shreya Vinjamuri"
+            ],
+            "committees": [
+              "Sophia Moylan"
+            ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Aarthi Balaji"],
-            "committees": ["Maya Ashok", "Prisha Thogulva"]
-          },
-          {
-            "time": "4:30 - 5:00",
-            "officers": ["Aarthi Balaji"],
+            "time": "3:00-3:30",
+            "officers": [
+              "Michelle Sun",
+              "Shreya Vinjamuri"
+            ],
             "committees": []
+          },
+          {
+            "time": "3:30-4:00",
+            "officers": [
+              "Michelle Sun",
+              "Shreya Vinjamuri"
+            ],
+            "committees": []
+          },
+          {
+            "time": "4:00-4:30",
+            "officers": [
+              "Michelle Sun"
+            ],
+            "committees": [
+              "Jessica Xu"
+            ]
+          },
+          {
+            "time": "4:30-5:00",
+            "officers": [
+              "Michelle Sun"
+            ],
+            "committees": [
+              "Jessica Xu"
+            ]
           }
         ]
       }
     ]
   },
-
   {
     "week2": [
       {
         "heading": "Monday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Kavya Puranam", "Neha Vardhaman"],
-            "committees": []
+            "time": "2:00-2:30",
+            "officers": [
+              "Saloni Vaishnav",
+              "Firmiana Wang",
+              "Elaina Xiao"
+            ],
+            "committees": [
+              "Rachel Chen",
+              "Skyla Jin",
+              "Swarnika Bhardwaj"
+            ]
           },
           {
-            "time": "2:30 - 3:00",
-            "officers": ["Kavya Puranam", "Neha Vardhaman"],
-            "committees": []
+            "time": "2:30-3:00",
+            "officers": [
+              "Saloni Vaishnav",
+              "Firmiana Wang",
+              "Elaina Xiao"
+            ],
+            "committees": [
+              "Ananya Kalidindi",
+              "Swarnika Bhardwaj "
+            ]
           },
           {
             "time": "3:00-3:30",
-            "officers": ["Kavya Puranam"],
-            "committees": ["Sami Duby", "Aditi Kumar", "Kay Rivera"]
+            "officers": [
+              "Firmiana Wang",
+              "Aditi Prasad",
+              "Elaina Xiao"
+            ],
+            "committees": [
+              "Brillina Wang",
+              "Ananya Kalidindi",
+              "Aditi Kumar"
+            ]
           },
           {
             "time": "3:30-4:00",
-            "officers": ["Kavya Puranam", "Anushri Mittal"],
-            "committees": ["Kay Rivera"]
+            "officers": [
+              "Firmiana Wang",
+              "Aditi Prasad",
+              "Elaina Xiao"
+            ],
+            "committees": [
+              "Fiona Hu",
+              "Jia Gill",
+              "Helena Ilic"
+            ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Sailaja Nallacheruvu", "Riya Jain", "Divya Koya"],
-            "committees": ["Saloni Vaishnav"]
+            "time": "4:00-4:30",
+            "officers": [
+              "Simone Schwaighart",
+              "Aditi Prasad"
+            ],
+            "committees": []
           },
           {
-            "time": "4:30 - 5:00",
-            "officers": ["Sailaja Nallacheruvu", "Riya Jain", "Divya Koya"],
+            "time": "4:30-5:00",
+            "officers": [
+              "Simone Schwaighart",
+              "Aditi Prasad"
+            ],
             "committees": []
           }
         ]
@@ -228,34 +430,74 @@
         "heading": "Tuesday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Ananya Rajagopal", "Garima Sharma"],
-            "committees": []
+            "time": "2:00-2:30",
+            "officers": [
+              "Saloni Vaishnav",
+              "Kathryn Lee"
+            ],
+            "committees": [
+              "Grace Ren",
+              "Nyssa Aftab",
+              "Ila Petrovic"
+            ]
           },
           {
-            "time": "2:30 - 3:00",
-            "officers": ["Ananya Rajagopal", "Shreya Deshpande", "Kalika Raje"],
-            "committees": []
+            "time": "2:30-3:00",
+            "officers": [
+              "Saloni Vaishnav",
+              "Kathryn Lee"
+            ],
+            "committees": [
+              "Grace Ren",
+              "Nyssa Aftab",
+              "Ila Petrovic"
+            ]
           },
           {
-            "time": "3:00 - 3:30",
-            "officers": ["Riya Jain", "Shreya Deshpande", "Kalika Raje"],
-            "committees": ["Abigail Gillham", "Kathryn Lee"]
+            "time": "3:00-3:30",
+            "officers": [
+              "Tia Kashyap",
+              "Kathryn Lee"
+            ],
+            "committees": [
+              "Zia Lu",
+              "Camryn Lee",
+              "Blessita Charly"
+            ]
           },
           {
-            "time": "3:30 - 4:00",
-            "officers": ["Riya Jain", "Shreya Vinjamuri"],
-            "committees": ["Abigail Gillham", "Kathryn Lee"]
+            "time": "3:30-4:00",
+            "officers": [
+              "Tia Kashyap",
+              "Kathryn Lee"
+            ],
+            "committees": [
+              "Zia Lu",
+              "Camryn Lee",
+              "Blessita Charly"
+            ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Shreya Vinjamuri", "Jillian Nylund"],
-            "committees": ["Anshi Mathur", "Julia Koite", "Maya Ajit"]
+            "time": "4:00-4:30",
+            "officers": [
+              "Kalika Raje",
+              "Tia Kashyap"
+            ],
+            "committees": [
+              "Sanjana Settipalli",
+              "Ashley Lee"
+            ]
           },
           {
-            "time": "4:30 - 5:00",
-            "officers": ["Shreya Vinjamuri", "Jillian Nylund"],
-            "committees": ["Anshi Mathur", "Julia Koite", "Maya Ajit"]
+            "time": "4:30-5:00",
+            "officers": [
+              "Kalika Raje",
+              "Tia Kashyap"
+            ],
+            "committees": [
+              "Sanjana Settipalli",
+              "Ashley Lee"
+            ]
           }
         ]
       },
@@ -263,46 +505,75 @@
         "heading": "Wednesday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Jillian Nylund"],
-            "committees": []
-          },
-          {
-            "time": "2:30 - 3:00",
-            "officers": ["Jillian Nylund", "Sailaja Nallacheruvu"],
-            "committees": []
-          },
-          {
-            "time": "3:00 - 3:30",
-            "officers": ["Sailaja Nallacheruvu"],
-            "committees": [
-              "Jade Huang",
-              "Shyamala Vasireddy",
-              "Kashvi Panjolia"
-            ]
-          },
-          {
-            "time": "3:30 - 4:00",
+            "time": "2:00-2:30",
             "officers": [
-              "Akshata Tiwari",
-              "Shreya Deshpande",
-              "Anushri Mittal"
+              "Karen Gao",
+              "Annapoorna Narayan",
+              "Shagun Khare"
             ],
             "committees": [
-              "Jade Huang",
-              "Shyamala Vasireddy",
-              "Kashvi Panjolia"
+              "Sahasra Kotarkonda"
             ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Shreya Deshpande", "Kalika Raje", "Divya Koya"],
-            "committees": ["Shreya Jangada"]
+            "time": "2:30-3:00",
+            "officers": [
+              "Karen Gao",
+              "Annapoorna Narayan",
+              "Shagun Khare"
+            ],
+            "committees": [
+              "Jazmin Uribe",
+              "Chloe Bote"
+            ]
           },
           {
-            "time": "4:30 - 5:00",
-            "officers": ["Kalika Raje", "Shreya Vinjamuri", "Divya Koya"],
-            "committees": ["Shreya Jangada"]
+            "time": "3:00-3:30",
+            "officers": [
+              "Emma Maxwell",
+              "Annapoorna Narayan"
+            ],
+            "committees": [
+              "Jazmin Uribe",
+              "Chloe Bote"
+            ]
+          },
+          {
+            "time": "3:30-4:00",
+            "officers": [
+              "Emma Maxwell",
+              "Shreya Deshpande",
+              "Annapoorna Narayan"
+            ],
+            "committees": [
+              "Sriya Gottiparthi",
+              "Siya Choudhary",
+              "Sahana Sankar"
+            ]
+          },
+          {
+            "time": "4:00-4:30",
+            "officers": [
+              "Emma Maxwell",
+              "Simone Schwaighart",
+              "Shreya Deshpande"
+            ],
+            "committees": [
+              "Tanishka Suman",
+              "Anisha Dasgupta"
+            ]
+          },
+          {
+            "time": "4:30-5:00",
+            "officers": [
+              "Emma Maxwell",
+              "Simone Schwaighart"
+            ],
+            "committees": [
+              "Nicole Hu",
+              "Anisha Dasgupta",
+              "Sailaja Nallacheruvu"
+            ]
           }
         ]
       },
@@ -310,34 +581,71 @@
         "heading": "Thursday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Ananya Rajagopal", "Garima Sharma", "Anushri Mittal"],
-            "committees": ["Aditi Shrivastava"]
+            "time": "2:00-2:30",
+            "officers": [
+              "Shriya Dave"
+            ],
+            "committees": [
+              "Taniya Agrawal",
+              "Vittoria Gallina",
+              "Caroline Feng"
+            ]
           },
           {
-            "time": "2:30 - 3:00",
-            "officers": ["Ananya Rajagopal", "Garima Sharma", "Anushri Mittal"],
-            "committees": ["Aditi Shrivastava"]
+            "time": "2:30-3:00",
+            "officers": [
+              "Shriya Dave"
+            ],
+            "committees": [
+              "Taniya Agrawal",
+              "Vittoria Gallina",
+              "Caroline Feng"
+            ]
           },
           {
-            "time": "3:00 - 3:30",
-            "officers": ["Garima Sharma"],
-            "committees": []
+            "time": "3:00-3:30",
+            "officers": [
+              "Kavya Puranam",
+              "Shriya Dave"
+            ],
+            "committees": [
+              "Ashley Li"
+            ]
           },
           {
-            "time": "3:30 - 4:00",
-            "officers": ["Akshata Tiwari"],
-            "committees": []
+            "time": "3:30-4:00",
+            "officers": [
+              "Kavya Puranam",
+              "Shreya Deshpande",
+              "Shriya Dave"
+            ],
+            "committees": [
+              "Lauren Peng",
+              "Ashley Li"
+            ]
           },
           {
-            "time": "4:00 - 4:30",
-            "officers": ["Akshata Tiwari"],
-            "committees": ["Firmiana Wang", "Thea Surya", "Shalini Sivakumar"]
+            "time": "4:00-4:30",
+            "officers": [
+              "Kavya Puranam",
+              "Kalika Raje",
+              "Shreya Deshpande"
+            ],
+            "committees": [
+              "Kirthi Shankar"
+            ]
           },
           {
-            "time": "4:30 - 5:00",
-            "officers": ["Akshata Tiwari"],
-            "committees": ["Firmiana Wang", "Thea Surya", "Shalini Sivakumar"]
+            "time": "4:30-5:00",
+            "officers": [
+              "Kavya Puranam",
+              "Kalika Raje"
+            ],
+            "committees": [
+              "Anshi Mathur",
+              "Kirthi Shankar",
+              "Sahasra Kotarkonda"
+            ]
           }
         ]
       },
@@ -345,34 +653,63 @@
         "heading": "Friday",
         "rows": [
           {
-            "time": "2:00 - 2:30",
-            "officers": ["Neha Vardhaman", "Akriti Arora", "Twinkle Yeruva"],
+            "time": "2:00-2:30",
+            "officers": [
+              "Shagun Khare",
+              "Karen Gao",
+              "Shreya Vinjamuri"
+            ],
+            "committees": [
+              "Shruthi Vudaru",
+              "Megan Tran"
+            ]
+          },
+          {
+            "time": "2:30-3:00",
+            "officers": [
+              "Shagun Khare",
+              "Karen Gao",
+              "Shreya Vinjamuri"
+            ],
+            "committees": [
+              "Shruthi Vudaru"
+            ]
+          },
+          {
+            "time": "3:00-3:30",
+            "officers": [
+              "Michelle Sun",
+              "Shreya Vinjamuri"
+            ],
             "committees": []
           },
           {
-            "time": "2:30 - 3:00",
-            "officers": ["Neha Vardhaman", "Akriti Arora", "Twinkle Yeruva"],
+            "time": "3:30-4:00",
+            "officers": [
+              "Michelle Sun",
+              "Shreya Vinjamuri"
+            ],
             "committees": []
           },
           {
-            "time": "3:00 - 3:30",
-            "officers": ["Aarthi Balaji", "Akriti Arora", "Twinkle Yeruva"],
-            "committees": ["Nancy Zhang"]
+            "time": "4:00-4:30",
+            "officers": [
+              "Michelle Sun"
+            ],
+            "committees": [
+              "Aarthi Balaji",
+              "Mayumi Suzue-Pan"
+            ]
           },
           {
-            "time": "3:30 - 4:00",
-            "officers": ["Aarthi Balaji", "Akriti Arora", "Twinkle Yeruva"],
-            "committees": ["Nancy Zhang"]
-          },
-          {
-            "time": "4:00 - 4:30",
-            "officers": ["Aarthi Balaji"],
-            "committees": []
-          },
-          {
-            "time": "4:30 - 5:00",
-            "officers": ["Aarthi Balaji"],
-            "committees": []
+            "time": "4:30-5:00",
+            "officers": [
+              "Michelle Sun"
+            ],
+            "committees": [
+              "Aarthi Balaji",
+              "Mayumi Suzue-Pan"
+            ]
           }
         ]
       }

--- a/src/styles/pages/OpenOffice.module.css
+++ b/src/styles/pages/OpenOffice.module.css
@@ -6,7 +6,7 @@
 }
 
 .desktop {
-   display: block;
+  display: block;
 }
 
 @media (max-width: 768px) {

--- a/src/styles/pages/OpenOffice.module.css
+++ b/src/styles/pages/OpenOffice.module.css
@@ -6,14 +6,22 @@
 }
 
 .desktop {
-  @media (max-width: 768px) {
-    display: none !important;
+   display: block;
+}
+
+@media (max-width: 768px) {
+  .desktop {
+    display: none;
   }
 }
 
 .mobile {
-  @media (min-width: 769px) {
-    display: none !important;
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .mobile {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

Issue with media queries prevented open office cal from being displayed in production environment.

## Screenshots
<img width="1036" alt="Screenshot 2024-10-16 at 7 26 33 PM" src="https://github.com/user-attachments/assets/35365a9a-08ec-49f1-a9ae-f9da153cbe49">

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
