### PR TITLE
update global styles according to figma

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ A few sentences describing the overall goals of the pull request's commits. If a
 -->
 
 <!-- Addresses #<number> -->
+
 Addresses: <(link notion task here)>
 
 ## Screenshots

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,6 @@
 @import '~bootstrap/dist/css/bootstrap.min.css';
+@import url('https://fonts.googleapis.com/css?family=Roboto Mono');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap');
 
 :root {
   --max-width: 1100px;
@@ -35,9 +37,7 @@ body {
 }
 
 body {
-  background: linear-gradient(#ffb2da, #cbedff);
-  background-attachment: fixed;
-  background-repeat: no-repeat;
+  background-color: #ffeaf5;
 }
 
 a {
@@ -52,43 +52,55 @@ a {
 }
 
 h1 {
-  font-family: 'Audiowide' !important;
-  font-weight: 400;
-  font-size: 64px;
+  font-family: 'Roboto Mono';
+  font-weight: normal;
+  font-size: 48px;
   color: black;
 }
 
 h2 {
-  font-family: 'Audiowide' !important;
-  font-weight: 400;
-  font-size: 40px;
+  font-family: 'Roboto Mono';
+  font-weight: normal;
+  font-size: 32px;
   color: black;
 }
 
 h3 {
-  font-family: 'Lato' !important;
-  font-weight: 700;
-  color: #21636c;
-  font-size: 28px; /* Adjusted to 28px */
+  font-family: 'Roboto Mono';
+  color: black;
+  font-size: 30px;
+  font-weight: bold;
+}
+
+h4 {
+  font-family: 'Roboto Mono';
+  font-size: 25px;
+  color: black;
+}
+
+h5 {
+  font-family: 'Roboto';
+  font-size: 16px;
+  color: black;
 }
 
 p {
-  font-family: 'Lato';
-  font-weight: 700;
+  font-family: 'Roboto';
+  font-weight: normal;
   font-size: 20px;
-  color: #21636c;
   margin-bottom: 0;
+  color: black;
 }
 
 ul {
-  color: #21636c;
+  color: black;
 }
 
 li {
-  font-family: 'Lato';
-  font-weight: 700;
-  font-size: 20px;
-  color: #21636c;
+  font-family: 'Roboto';
+  font-weight: normal;
+  font-size: 16px;
+  color: black;
 }
 
 @media only screen and (max-width: 768px) {


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->
Updated global styles according to Figma including body background color, h1, h2, h3, h4, h5, p, and li tags.

## Screenshots
h1 example: 
Old styling:
<img width="1320" alt="Screenshot 2024-10-20 at 3 52 51 PM" src="https://github.com/user-attachments/assets/e1d9ac3c-87f8-4c28-9185-eb305e2357f1">

New styling:
<img width="942" alt="Screenshot 2024-10-20 at 3 53 10 PM" src="https://github.com/user-attachments/assets/48a2fc89-f979-4bec-80ad-090e0044a96d">


<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
