### PR TITLE
Create past events page

### DIFF
--- a/src/pages/past-events.js
+++ b/src/pages/past-events.js
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import ComputerWindow from '../components/general/ComputerWindowComponent';
+import styles from '@/styles/pages/PastEvents.module.css';
+import UpcomingEvent from '../components/events/UpcomingEvent';
+
+function PastEvents() {
+  //   const events = [];
+  const [events, setEvents] = useState([]);
+  const [eventsByMonth, setEventsByMonth] = useState({});
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      try {
+        // eslint-disable-next-line operator-linebreak
+        const eventsUrl =
+          'https://script.google.com/macros/s/AKfycbwrdoAI4aL0-thhyqZ-mYo03DEPq_lhHAQjRtOxo_16kXcoieQ2E3pB1wZ94u6GgfP4Ew/exec';
+        const res = await fetch(eventsUrl);
+        const { events: fetchedEvents } = await res.json();
+        setEvents(
+          fetchedEvents
+            .map(({ startTime, endTime, title, location, description }) => {
+              const startDate = new Date(startTime);
+              const endDate = new Date(endTime);
+
+              const dateOptions = {
+                weekday: 'long',
+                month: 'long',
+                day: '2-digit',
+              };
+              const date = startDate.toLocaleDateString('en-US', dateOptions);
+
+              const timeOptions = {
+                hour: 'numeric',
+                minute: '2-digit',
+              };
+              const start = startDate.toLocaleTimeString('en-US', timeOptions);
+              const end = endDate.toLocaleTimeString('en-US', timeOptions);
+
+              return {
+                title,
+                date,
+                time: `${start} - ${end}`,
+                location,
+                description,
+              };
+            })
+            .reverse(),
+        );
+      } catch (error) {
+        // console.error('Error fetching events:', error);
+      }
+    };
+
+    fetchEvents();
+  }, []);
+
+  useEffect(() => {
+    const eventsMap = new Map();
+    events.forEach((event) => {
+      const month = event.date.split(' ')[1];
+      // console.log(event.date);
+      if (eventsMap.has(month)) {
+        eventsMap.get(month).push(event);
+      } else {
+        eventsMap.set(month, [event]);
+      }
+    });
+    setEventsByMonth(eventsMap);
+  }, [events]);
+
+  return (
+    <div className={styles.main}>
+      <ComputerWindow className={styles.title}>
+        <h2>Past Events</h2>
+      </ComputerWindow>
+      {events.length === 0 ? (
+        <ComputerWindow showTopbar={false} className={styles.subHeader}>
+          <h3>Loading events...</h3>
+        </ComputerWindow>
+      ) : (
+        <div className={styles.eventsContainer}>
+          {Array.from(eventsByMonth).map(([month, monthEvents]) => (
+            <div key={month}>
+              <ComputerWindow showTopbar={false} className={styles.subHeader}>
+                <h3>{month}</h3>
+              </ComputerWindow>
+              <div className={styles.monthContainer}>
+                {monthEvents.map(({ title, date, time, location }, index) => (
+                  <UpcomingEvent
+                    key={index}
+                    title={title}
+                    date={date}
+                    time={time}
+                    location={location}
+                    className={styles.event}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+export default PastEvents;

--- a/src/pages/past-events.js
+++ b/src/pages/past-events.js
@@ -4,9 +4,9 @@ import styles from '@/styles/pages/PastEvents.module.css';
 import UpcomingEvent from '../components/events/UpcomingEvent';
 
 function PastEvents() {
-  //   const events = [];
   const [events, setEvents] = useState([]);
   const [eventsByMonth, setEventsByMonth] = useState({});
+  const [errorFetchingEvents, setErrorFetchingEvents] = useState(false);
 
   useEffect(() => {
     const fetchEvents = async () => {
@@ -47,7 +47,7 @@ function PastEvents() {
             .reverse(),
         );
       } catch (error) {
-        // console.error('Error fetching events:', error);
+        setErrorFetchingEvents(true);
       }
     };
 
@@ -58,7 +58,6 @@ function PastEvents() {
     const eventsMap = new Map();
     events.forEach((event) => {
       const month = event.date.split(' ')[1];
-      // console.log(event.date);
       if (eventsMap.has(month)) {
         eventsMap.get(month).push(event);
       } else {
@@ -68,8 +67,27 @@ function PastEvents() {
     setEventsByMonth(eventsMap);
   }, [events]);
 
+  if (errorFetchingEvents) {
+    return (
+      <div className={styles.pastEventsContainer}>
+        <ComputerWindow className={styles.title}>
+          <h2>Past Events</h2>
+        </ComputerWindow>
+        <ComputerWindow showTopbar={false} className={styles.subHeader}>
+          <h3>
+            Error fetching events. Check out our{' '}
+            <a href="https://calendar.google.com/calendar/u/6?cid=M2MyOGdwcHJjbm9zMHEyNTFvZG5sODc3bWNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">
+              <u>Google Calendar</u>
+            </a>
+            .
+          </h3>
+        </ComputerWindow>
+      </div>
+    );
+  }
+
   return (
-    <div className={styles.main}>
+    <div className={styles.pastEventsContainer}>
       <ComputerWindow className={styles.title}>
         <h2>Past Events</h2>
       </ComputerWindow>

--- a/src/styles/pages/PastEvents.module.css
+++ b/src/styles/pages/PastEvents.module.css
@@ -1,0 +1,44 @@
+.main {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  position: relative;
+}
+
+.title h2 {
+  margin: 1rem;
+  font-size: 42px;
+  text-align: center;
+}
+
+.main .title {
+  text-align: center;
+  margin: 2rem auto 0;
+  width: 90%;
+}
+
+.subHeader h3 {
+  margin: 1rem;
+  font-weight: 300;
+  font-size: 32px;
+}
+
+.main .subHeader {
+  width: 80vw;
+  text-align: center;
+  margin: 3rem auto 2rem;
+}
+
+.monthContainer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 80vw;
+  gap: 2rem;
+  margin: auto;
+}
+
+.eventsContainer {
+  margin: auto;
+}

--- a/src/styles/pages/PastEvents.module.css
+++ b/src/styles/pages/PastEvents.module.css
@@ -1,4 +1,4 @@
-.main {
+.pastEventsContainer {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -8,11 +8,10 @@
 
 .title h2 {
   margin: 1rem;
-  font-size: 42px;
   text-align: center;
 }
 
-.main .title {
+.title {
   text-align: center;
   margin: 2rem auto 0;
   width: 90%;
@@ -20,11 +19,9 @@
 
 .subHeader h3 {
   margin: 1rem;
-  font-weight: 300;
-  font-size: 32px;
 }
 
-.main .subHeader {
+.subHeader {
   width: 80vw;
   text-align: center;
   margin: 3rem auto 2rem;


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

The past events page displays events from the past 6 months in reverse chronological order with the months as subheaders

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
<img width="1470" alt="Screenshot 2025-01-27 at 3 06 35 PM" src="https://github.com/user-attachments/assets/4223af3a-ffc0-4e05-b29a-c721176d19f8" />

