### PR TITLE
Make past events button smaller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5113,6 +5113,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.22.tgz",
+      "integrity": "sha512-5IhDDTPEbzPR31ZzqHe90LnNe7BlJUZvC4sA1thPJV6oN5WmtWjZ0bOYfNsyZx00FJt7gggNs6SrsX0UEIcIpA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/styles/pages/Home.module.css
+++ b/src/styles/pages/Home.module.css
@@ -109,7 +109,7 @@
 
 .pastEventsButtonText {
   margin: 0;
-  padding: 1rem 10vw;
+  padding: 0.5rem 1vw;
 }
 
 .hiddenButton {


### PR DESCRIPTION
## Status:

<!--

:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

Make past events button smaller

## Screenshots
Old:
<img width="1161" alt="Screenshot 2025-02-23 at 1 49 20 PM" src="https://github.com/user-attachments/assets/0e4f3f5d-86b9-430d-9401-97f17879d616" />
New:
<img width="1224" alt="Screenshot 2025-02-23 at 1 49 07 PM" src="https://github.com/user-attachments/assets/e00e7c3b-5e03-4962-808a-9c5eb2560356" />


<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
