### PR TITLE
bug -- remove top bar buttons in headers

### DIFF
--- a/src/pages/past-events.js
+++ b/src/pages/past-events.js
@@ -70,7 +70,7 @@ function PastEvents() {
   if (errorFetchingEvents) {
     return (
       <div className={styles.pastEventsContainer}>
-        <ComputerWindow className={styles.title}>
+        <ComputerWindow className={styles.title} showButtons={false}>
           <h2>Past Events</h2>
         </ComputerWindow>
         <ComputerWindow showTopbar={false} className={styles.subHeader}>
@@ -88,7 +88,7 @@ function PastEvents() {
 
   return (
     <div className={styles.pastEventsContainer}>
-      <ComputerWindow className={styles.title}>
+      <ComputerWindow className={styles.title} showButtons={false}>
         <h2>Past Events</h2>
       </ComputerWindow>
       {events.length === 0 ? (

--- a/src/pages/team.js
+++ b/src/pages/team.js
@@ -180,7 +180,7 @@ export default function Team() {
 
   return (
     <div className={styles.main}>
-      <ComputerWindow className={styles.title}>
+      <ComputerWindow className={styles.title} showButtons={false}>
         <h2>Our Team</h2>
       </ComputerWindow>
       <Image

--- a/src/sections/AboutUsSection.js
+++ b/src/sections/AboutUsSection.js
@@ -7,8 +7,8 @@ export default function AboutUsSection() {
   return (
     <div className={`${styles.container}`}>
       <div className={styles.computerWindowContainer}>
-        <ComputerWindow className={styles.window}>
-          <div className={styles.windowContent}>
+        <ComputerWindow className={styles.window} showButtons={false}>
+          <div className={styles.windowContent} >
             <h1>Illinois Women in Computer Science</h1>
           </div>
         </ComputerWindow>


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

removed top bar buttons from computer window header on about us, past events, and our team pages

Addresses #<number>

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
