### PR TITLE
bug - key hover now wcs pink instead of bright pink

### DIFF
--- a/src/styles/components/Key.module.css
+++ b/src/styles/components/Key.module.css
@@ -72,19 +72,19 @@
 }
 
 .keyTop:hover::before {
-  background-color: #ff7cc0;
+  background-color: var(--wcs-pink);
 }
 
 .keyTop:hover .keyRight::before {
-  border-right: 10px solid #ff7cc0;
+  border-right: 10px solid var(--wcs-pink);
 }
 
 .keyTop:hover .keyBottom::before {
-  background-color: #ff7cc0;
+  background-color: var(--wcs-pink);
 }
 
 .keyTop:hover .keyBody {
-  background-color: #ff7cc0;
+  background-color: var(--wcs-pink);
   color: #ffe3f2;
 }
 

--- a/src/styles/sections/Footer.module.css
+++ b/src/styles/sections/Footer.module.css
@@ -29,7 +29,7 @@
 .binaryContainer {
   position: relative;
   width: 100%;
-  padding-top: 20%; /* Adjust this percentage to control the height */
+  padding-top: 20%; 
   overflow: hidden;
   margin-bottom: 1rem;
 }
@@ -38,8 +38,6 @@
   position: absolute;
   top: 0;
   left: 0;
-  /* width: 100%;
-    height: 100%; */
   object-fit: cover;
 }
 


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

changed key component styling so hovering would turn key from light pink to wcs pink instead of bright pink

Addresses #<number>

## Screenshots

![image](https://github.com/user-attachments/assets/0c979cb8-1da9-4a2f-babb-4f9d42a071d6)
