### PR TITLE
Fix Team Page Animation Resizing Issue

### DIFF
--- a/src/pages/team.js
+++ b/src/pages/team.js
@@ -22,11 +22,22 @@ export default function Team() {
   const [screenWidth, setScreenWidth] = useState(0);
 
   useEffect(() => {
+    const handleResize = () => {
+      setScreenWidth(window.innerWidth);
+    };
     setScreenWidth(window.innerWidth);
+
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   useEffect(() => {
-    if (screenWidth > 780) {
+    const createAnimation = () => {
+      if (screenWidth <= 780) {
+        return;
+      }
+
       // eslint-disable-next-line global-require
       const { ScrollTrigger } = require('gsap/ScrollTrigger');
 
@@ -76,7 +87,15 @@ export default function Team() {
           });
         }
       });
+    };
+
+    if (screenWidth <= 780) {
+      gsap.utils.toArray(`.${styles.outerContainer}`).forEach((container) => {
+        gsap.killTweensOf(container);
+        gsap.set(container, { clearProps: 'all' });
+      });
     }
+    createAnimation();
   }, [screenWidth]);
 
   const renderCommitteeSection = (

--- a/src/pages/team.js
+++ b/src/pages/team.js
@@ -1,12 +1,15 @@
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/dist/ScrollTrigger';
 
 import OfficerCard from '../components/OfficerCard';
 import officerData from '../data/officers.json';
 import committeeData from '../data/committees.json';
 import styles from '@/styles/pages/Team.module.css';
 import ComputerWindow from '../components/general/ComputerWindowComponent';
+
+gsap.registerPlugin(ScrollTrigger);
 
 export default function Team() {
   const committeeCaptions = [
@@ -24,6 +27,7 @@ export default function Team() {
   useEffect(() => {
     const handleResize = () => {
       setScreenWidth(window.innerWidth);
+      setTimeout(() => ScrollTrigger.refresh(), 100);
     };
     setScreenWidth(window.innerWidth);
 
@@ -37,11 +41,6 @@ export default function Team() {
       if (screenWidth <= 780) {
         return;
       }
-
-      // eslint-disable-next-line global-require
-      const { ScrollTrigger } = require('gsap/ScrollTrigger');
-
-      gsap.registerPlugin(ScrollTrigger);
       const committeeInnerContainers = document.querySelectorAll(
         `.${styles.outerContainer}`,
       );
@@ -67,6 +66,7 @@ export default function Team() {
               start: '40% 80%',
               end: '80% 70%',
               scrub: true,
+              onUpdate: () => ScrollTrigger.update(),
             },
           });
         } else {
@@ -83,6 +83,7 @@ export default function Team() {
               start: '50% 80%',
               end: '55% 70%',
               scrub: true,
+              onUpdate: () => ScrollTrigger.update(),
             },
           });
         }

--- a/src/styles/pages/Team.module.css
+++ b/src/styles/pages/Team.module.css
@@ -64,7 +64,6 @@
   justify-content: center;
   width: fit-content;
   position: sticky;
-  /* top: 125px; */
   top: calc(50vh - 250px);
   gap: 200px;
   height: 500px;
@@ -146,6 +145,10 @@
   gap: 1vw;
 }
 
+.outerContainer:last-child {
+  margin-bottom: 0;
+}
+
 @media (max-width: 992px) {
   .committeeDescription h4 {
     font-size: 20px;
@@ -211,7 +214,8 @@
   .outerContainer {
     height: fit-content;
     width: 100%;
-    margin-bottom: 5rem;
+    margin-bottom: 10vw;
+    position: relative;
   }
 
   .committeeDescription {
@@ -235,6 +239,7 @@
     flex-direction: column;
     gap: 1rem;
     height: fit-content;
+    max-height: none;
   }
 
   .imgCaption {

--- a/src/styles/pages/Team.module.css
+++ b/src/styles/pages/Team.module.css
@@ -64,7 +64,8 @@
   justify-content: center;
   width: fit-content;
   position: sticky;
-  top: 125px;
+  /* top: 125px; */
+  top: calc(50vh - 250px);
   gap: 200px;
   height: 500px;
 }


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

<!-- Addresses #<number> -->

When it detects screen size changing, it uses ScrollTrigger.refresh() and ScrollTrigger.update() to re-calculate its start and end values 

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
