### PR TITLE
Remove Animations From Team Page

### DIFF
--- a/src/pages/team.js
+++ b/src/pages/team.js
@@ -1,15 +1,9 @@
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
-import { gsap } from 'gsap';
-import { ScrollTrigger } from 'gsap/dist/ScrollTrigger';
-
 import OfficerCard from '../components/OfficerCard';
 import officerData from '../data/officers.json';
 import committeeData from '../data/committees.json';
 import styles from '@/styles/pages/Team.module.css';
 import ComputerWindow from '../components/general/ComputerWindowComponent';
-
-gsap.registerPlugin(ScrollTrigger);
 
 export default function Team() {
   const committeeCaptions = [
@@ -21,83 +15,6 @@ export default function Team() {
     'Friendsgiving 2024',
     'Quad Day',
   ];
-
-  const [screenWidth, setScreenWidth] = useState(0);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setScreenWidth(window.innerWidth);
-      setTimeout(() => ScrollTrigger.refresh(), 100);
-    };
-    setScreenWidth(window.innerWidth);
-
-    window.addEventListener('resize', handleResize);
-
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  useEffect(() => {
-    const createAnimation = () => {
-      if (screenWidth <= 780) {
-        return;
-      }
-      const committeeInnerContainers = document.querySelectorAll(
-        `.${styles.outerContainer}`,
-      );
-
-      const committees = document.querySelectorAll(`.${styles.committee}`);
-      const imgContainers = document.querySelectorAll(
-        `.${styles.imgContainer}`,
-      );
-
-      committeeInnerContainers.forEach((container, index) => {
-        const committeeWidth = committees[index].offsetWidth;
-        const imgContainerWidth = imgContainers[index].offsetWidth;
-
-        if (index % 2 === 0) {
-          gsap.set(container, {
-            marginLeft: `${-(imgContainerWidth + 200 - screenWidth / 2 + committeeWidth / 2)}px`,
-          });
-          const newMarginLeft = screenWidth / 2 - imgContainerWidth / 2;
-          gsap.to(container, {
-            marginLeft: `${newMarginLeft}px`,
-            scrollTrigger: {
-              trigger: container,
-              start: '40% 80%',
-              end: '80% 70%',
-              scrub: true,
-              onUpdate: () => ScrollTrigger.update(),
-            },
-          });
-        } else {
-          gsap.set(container, {
-            marginLeft: `${screenWidth / 2 - committeeWidth / 2}px`,
-          });
-          // eslint-disable-next-line operator-linebreak
-          const newMarginLeft =
-            committeeWidth + 200 - screenWidth / 2 + imgContainerWidth / 2;
-          gsap.to(container, {
-            marginLeft: `-${newMarginLeft}px`,
-            scrollTrigger: {
-              trigger: container,
-              start: '50% 80%',
-              end: '55% 70%',
-              scrub: true,
-              onUpdate: () => ScrollTrigger.update(),
-            },
-          });
-        }
-      });
-    };
-
-    if (screenWidth <= 780) {
-      gsap.utils.toArray(`.${styles.outerContainer}`).forEach((container) => {
-        gsap.killTweensOf(container);
-        gsap.set(container, { clearProps: 'all' });
-      });
-    }
-    createAnimation();
-  }, [screenWidth]);
 
   const renderCommitteeSection = (
     position,
@@ -114,85 +31,37 @@ export default function Team() {
       // eslint-disable-next-line function-paren-newline
     );
 
-    if (position === 'Left' || screenWidth < 780) {
-      return (
-        <div
-          className={styles.outerContainer}
-          style={title === 'Marketing' ? { marginBottom: '0' } : {}}
-        >
-          <div className={styles.middleContainer}>
-            <div className={styles.innerContainer}>
-              <div className={styles.imgContainer}>
-                <img className={styles.img} src={image} alt={image} />
-                <div className={styles.imgCaption}>{caption}</div>
-              </div>
-              <div
-                className={`${styles[`committee${position}`]} ${styles.committee}`}
-              >
-                <ComputerWindow
-                  topbarColor="wcs-pink"
-                  className={styles.committeeWindow}
-                >
-                  <div className={styles.committeeDescription}>
-                    <h4>{title} Committee</h4>
-                    <p>{description}</p>
-                  </div>
-                </ComputerWindow>
-
-                <div className={styles.officerPics}>
-                  {officersList.map((officer, index) => (
-                    <OfficerCard
-                      key={index}
-                      name={officer.name}
-                      position={officer.position}
-                      netid={officer.netid}
-                      officer={officer}
-                      className={styles.officerCard}
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
     return (
       <div className={styles.outerContainer}>
-        <div className={styles.middleContainer}>
-          <div className={styles.innerContainer}>
-            <div
-              className={`${styles[`committee${position}`]} ${styles.committee}`}
-            >
-              <ComputerWindow
-                topbarColor="wcs-pink"
-                className={styles.committeeWindow}
-              >
-                <div className={styles.committeeDescription}>
-                  <h4>{title} Committee</h4>
-                  <p>{description}</p>
-                </div>
-              </ComputerWindow>
+        <div
+          className={`${styles[`committee${position}`]} ${styles.committee}`}
+        >
+          <ComputerWindow
+            topbarColor="wcs-pink"
+            className={styles.committeeWindow}
+          >
+            <div className={styles.committeeDescription}>
+              <h4>{title} Committee</h4>
+              <p>{description}</p>
+            </div>
+          </ComputerWindow>
 
-              <div className={styles.officerPics}>
-                {officersList.map((officer, index) => (
-                  <OfficerCard
-                    key={index}
-                    name={officer.name}
-                    position={officer.position}
-                    netid={officer.netid}
-                    officer={officer}
-                    className={styles.officerCard}
-                  />
-                ))}
-              </div>
-            </div>
-            <div className={styles.imgContainer}>
-              <img className={styles.img} src={image} alt={image} />
-              <div className={styles.imgCaption}>{caption}</div>
-            </div>
+          <div className={styles.officerPics}>
+            {officersList.map((officer, index) => (
+              <OfficerCard
+                key={index}
+                name={officer.name}
+                position={officer.position}
+                netid={officer.netid}
+                officer={officer}
+                className={styles.officerCard}
+              />
+            ))}
           </div>
+        </div>
+        <div className={styles.imgContainer}>
+          <img className={styles.img} src={image} alt={image} />
+          <div className={styles.imgCaption}>{caption}</div>
         </div>
       </div>
     );

--- a/src/styles/pages/Team.module.css
+++ b/src/styles/pages/Team.module.css
@@ -86,11 +86,12 @@
 
 .imgCaption {
   background-color: var(--light-pink);
-  position: relative;
+  position: absolute;
+  left: 0;
+  bottom: 0;
   padding: 1rem;
   border-radius: 20px;
-  width: fit-content;
-  margin: 1rem auto;
+  transform: translate(-30%, 80%);
 }
 
 .committeeLeft {

--- a/src/styles/pages/Team.module.css
+++ b/src/styles/pages/Team.module.css
@@ -52,21 +52,14 @@
 }
 
 .outerContainer {
-  height: 200vh;
+  height: fit-content;
   width: 100vw;
   position: relative;
-  margin-bottom: 400px;
-}
-
-.innerContainer {
+  margin-bottom: 250px;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  width: fit-content;
-  position: sticky;
-  top: calc(50vh - 250px);
-  gap: 200px;
-  height: 500px;
+  gap: 2rem;
 }
 
 .committee {
@@ -91,20 +84,13 @@
   position: relative;
 }
 
-.middleContainer {
-  position: relative;
-  height: 100%;
-}
-
 .imgCaption {
   background-color: var(--light-pink);
-  position: absolute;
-  left: 0;
-  bottom: 0;
+  position: relative;
   padding: 1rem;
-
   border-radius: 20px;
-  transform: translate(-30%, 80%);
+  width: fit-content;
+  margin: 1rem auto;
 }
 
 .committeeLeft {
@@ -193,22 +179,6 @@
     gap: 2rem;
     width: 100%;
     height: fit-content;
-  }
-
-  .innerContainer {
-    flex-direction: column-reverse;
-    align-items: center;
-    gap: 1rem;
-    width: 100%;
-    margin: 0 auto;
-    position: relative;
-    height: fit-content;
-    top: 0;
-  }
-
-  .middleContainer {
-    height: fit-content;
-    width: 100%;
   }
 
   .outerContainer {


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready
## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

<!-- Addresses #<number> -->

- Remove gsap scrolling animation
- Stack committee description and image on top of each other

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
<img width="1246" alt="Screenshot 2025-03-25 at 8 07 12 PM" src="https://github.com/user-attachments/assets/06bbd1e1-84de-4c90-a753-d28db6c2b737" />
<img width="1468" alt="Screenshot 2025-03-25 at 8 07 23 PM" src="https://github.com/user-attachments/assets/cc25da22-be92-40f8-9aff-b4ed7825e802" />


