### PR TITLE
Na/remove arrows in open office

### DIFF
--- a/src/sections/UpcomingEventsSection.js
+++ b/src/sections/UpcomingEventsSection.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 import ComputerWindow from '../components/general/ComputerWindowComponent';
 import EventsWindow from '../components/events/EventsWindow';
 import UpcomingEvent from '../components/events/UpcomingEvent';
@@ -185,13 +184,6 @@ export default function UpcomingEventsSection() {
                       <Link href="/" onClick={closeModal}>
                         <p>Make an Appointment</p>
                       </Link>
-                      <Image
-                        src="/assets/design-vectors/pointer.svg"
-                        width={22}
-                        height={22}
-                        className={styles.modalCursor}
-                        alt="pointer"
-                      />
                     </div>
                   </div>
                   <div className={styles2.eventInfo}>
@@ -215,13 +207,6 @@ export default function UpcomingEventsSection() {
                       <Link href="/openoffice">
                         <p>Check out the Calendar</p>
                       </Link>
-                      <Image
-                        src="/assets/design-vectors/pointer.svg"
-                        width={22}
-                        height={22}
-                        className={styles.modalCursor}
-                        alt="pointer"
-                      />
                     </div>
                   </div>
                   <button


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

removed arrows in opened open office modal in upcoming events

Addresses: <(link notion task here)>

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
