### PR TITLE
Mobile Responsiveness for Get Help Section

### DIFF
--- a/src/sections/GetHelpSection.js
+++ b/src/sections/GetHelpSection.js
@@ -4,113 +4,315 @@ import ComputerWindow from '../components/general/ComputerWindowComponent';
 import styles from '@/styles/sections/GetHelpSection.module.css';
 import resourcesData from '@/data/resources.json';
 
+export function DesktopContainer({ children }) {
+  return <div className={`${styles.desktop}`}>{children}</div>;
+}
+
+export function MobileContainer({ children }) {
+  return <div className={`${styles.mobile}`}>{children}</div>;
+}
+
 export default function GetHelpSection() {
   const [openIndex, setOpenIndex] = useState(null);
+  const [containerIndex, setContainerIndex] = useState(0);
 
   const toggleDropdown = (index) => {
     setOpenIndex(openIndex === index ? null : index);
   };
 
-  return (
-    <div className={styles.window}>
-      <ComputerWindow topbarColor="wcs-pink" showButtons={false}>
-        <div className={styles.container}>
-          <div className={styles.mentalhContainer}>
+  const renderContainer = () => {
+    if (containerIndex === 0) {
+      return (
+        <div className={styles.mentalhContainer}>
+          <div className={styles.containerHeader}>
             <h3>Mental Health</h3>
-            {resourcesData[0].items.map((resource, index) => (
-              <div key={index} className={styles.resourceItem}>
-                <button
-                  type="button"
-                  onClick={() => toggleDropdown(index)}
-                  className={`${styles.resourceName} ${openIndex === index ? styles.open : ''}`}
-                >
-                  {resource.name}
-                  <Image
-                    src="/assets/design-vectors/dropdown-arrow.svg"
-                    alt="Dropdown icon"
-                    width={18}
-                    height={18}
-                    className={styles.dropdownIcon}
-                  />
-                </button>
-                {openIndex === index && (
-                  <div className={styles.dropdownContent}>
-                    <p>{resource.description}</p>
-                  </div>
-                )}
-              </div>
-            ))}
+            <button
+              type="button"
+              onClick={() => setContainerIndex(1)}
+              className={styles.changeContainer}
+            >
+              <Image
+                src="/assets/design-vectors/dropdown-arrow.svg"
+                alt="Dropdown icon"
+                width={18}
+                height={18}
+                className={styles.dropdownIcon}
+                style={{
+                  transform: 'rotate(-90deg)',
+                }}
+              />
+            </button>
           </div>
-          <div className={styles.academicContainer}>
-            <h3>Academic</h3>
-            {resourcesData[1].items.map((resource, index) => (
-              <div key={index} className={styles.resourceItem}>
-                <button
-                  type="button"
-                  onClick={
-                    () => toggleDropdown(index + resourcesData[0].items.length)
-                    // eslint-disable-next-line react/jsx-curly-newline
-                  }
-                  className={`${styles.resourceName} ${openIndex === index + resourcesData[0].items.length ? styles.open : ''}`}
-                >
-                  {resource.name}
-                  <Image
-                    src="/assets/design-vectors/dropdown-arrow.svg"
-                    alt="Dropdown icon"
-                    width={18}
-                    height={18}
-                    className={styles.dropdownIcon}
-                  />
-                </button>
-                {openIndex === index + resourcesData[0].items.length && (
-                  <div className={styles.dropdownContent}>
-                    <p>{resource.description}</p>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-          <div className={styles.otherContainer}>
-            <h3>Other</h3>
-            {resourcesData[2].items.map((resource, index) => (
-              <div key={index} className={styles.resourceItem}>
-                <button
-                  type="button"
-                  onClick={
-                    () =>
-                      toggleDropdown(
-                        // eslint-disable-next-line react/jsx-curly-newline
-                        index +
-                          resourcesData[0].items.length +
-                          resourcesData[1].items.length,
-                      ) // eslint-disable-next-line react/jsx-curly-newline
-                  }
-                  className={`${styles.resourceName} 
-                  ${openIndex === index + resourcesData[0].items.length + resourcesData[1].items.length ? styles.open : ''}`}
-                >
-                  {resource.name}
-                  <Image
-                    src="/assets/design-vectors/dropdown-arrow.svg"
-                    alt="Dropdown icon"
-                    width={18}
-                    height={18}
-                    className={styles.dropdownIcon}
-                  />
-                </button>
-                {openIndex ===
-                  // eslint-disable-next-line react/jsx-indent
-                  index +
-                    resourcesData[0].items.length +
-                    resourcesData[1].items.length && ( // eslint-disable-next-line react/jsx-indent
-                  <div className={styles.dropdownContent}>
-                    <p>{resource.description}</p>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
+          {resourcesData[0].items.map((resource, index) => (
+            <div key={index} className={styles.resourceItem}>
+              <button
+                type="button"
+                onClick={() => toggleDropdown(index)}
+                className={`${styles.resourceName} ${openIndex === index ? styles.open : ''}`}
+              >
+                {resource.name}
+                <Image
+                  src="/assets/design-vectors/dropdown-arrow.svg"
+                  alt="Dropdown icon"
+                  width={18}
+                  height={18}
+                  className={styles.dropdownIcon}
+                />
+              </button>
+              {openIndex === index && (
+                <div className={styles.dropdownContent}>
+                  <p>{resource.description}</p>
+                </div>
+              )}
+            </div>
+          ))}
         </div>
-      </ComputerWindow>
-    </div>
+      );
+    }
+
+    if (containerIndex === 1) {
+      return (
+        <div className={styles.academicContainer}>
+          <div className={styles.containerHeader}>
+            <button
+              type="button"
+              onClick={() => setContainerIndex(0)}
+              className={styles.changeContainer}
+            >
+              <Image
+                src="/assets/design-vectors/dropdown-arrow.svg"
+                alt="Dropdown icon"
+                width={18}
+                height={18}
+                className={styles.dropdownIcon}
+                style={{
+                  transform: 'rotate(90deg)',
+                }}
+              />
+            </button>
+            <h3>Academic</h3>
+            <button
+              type="button"
+              onClick={() => setContainerIndex(2)}
+              className={styles.changeContainer}
+            >
+              <Image
+                src="/assets/design-vectors/dropdown-arrow.svg"
+                alt="Dropdown icon"
+                width={18}
+                height={18}
+                className={styles.dropdownIcon}
+                style={{
+                  transform: 'rotate(-90deg)',
+                }}
+              />
+            </button>
+          </div>
+          {resourcesData[1].items.map((resource, index) => (
+            <div key={index} className={styles.resourceItem}>
+              <button
+                type="button"
+                onClick={
+                  () => toggleDropdown(index + resourcesData[0].items.length)
+                  // eslint-disable-next-line react/jsx-curly-newline
+                }
+                className={`${styles.resourceName} ${openIndex === index + resourcesData[0].items.length ? styles.open : ''}`}
+              >
+                {resource.name}
+                <Image
+                  src="/assets/design-vectors/dropdown-arrow.svg"
+                  alt="Dropdown icon"
+                  width={18}
+                  height={18}
+                  className={styles.dropdownIcon}
+                />
+              </button>
+              {openIndex === index + resourcesData[0].items.length && (
+                <div className={styles.dropdownContent}>
+                  <p>{resource.description}</p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div className={styles.otherContainer}>
+        <div className={styles.containerHeader}>
+          <button
+            type="button"
+            onClick={() => setContainerIndex(1)}
+            className={styles.changeContainer}
+          >
+            <Image
+              src="/assets/design-vectors/dropdown-arrow.svg"
+              alt="Dropdown icon"
+              width={18}
+              height={18}
+              className={styles.dropdownIcon}
+              style={{
+                transform: 'rotate(90deg)',
+              }}
+            />
+          </button>
+          <h3>Other</h3>
+        </div>
+        {resourcesData[2].items.map((resource, index) => (
+          <div key={index} className={styles.resourceItem}>
+            <button
+              type="button"
+              onClick={
+                () =>
+                  toggleDropdown(
+                    // eslint-disable-next-line react/jsx-curly-newline
+                    index +
+                      resourcesData[0].items.length +
+                      resourcesData[1].items.length,
+                  ) // eslint-disable-next-line react/jsx-curly-newline
+              }
+              className={`${styles.resourceName} 
+      ${openIndex === index + resourcesData[0].items.length + resourcesData[1].items.length ? styles.open : ''}`}
+            >
+              {resource.name}
+              <Image
+                src="/assets/design-vectors/dropdown-arrow.svg"
+                alt="Dropdown icon"
+                width={18}
+                height={18}
+                className={styles.dropdownIcon}
+              />
+            </button>
+            {openIndex ===
+              // eslint-disable-next-line react/jsx-indent
+              index +
+                resourcesData[0].items.length +
+                resourcesData[1].items.length && (
+              // eslint-disable-next-line react/jsx-indent
+              <div className={styles.dropdownContent}>
+                <p>{resource.description}</p>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <DesktopContainer>
+        <div className={styles.window}>
+          <ComputerWindow topbarColor="wcs-pink" showButtons={false}>
+            <div className={styles.container}>
+              <div className={styles.mentalhContainer}>
+                <h3>Mental Health</h3>
+                {resourcesData[0].items.map((resource, index) => (
+                  <div key={index} className={styles.resourceItem}>
+                    <button
+                      type="button"
+                      onClick={() => toggleDropdown(index)}
+                      className={`${styles.resourceName} ${openIndex === index ? styles.open : ''}`}
+                    >
+                      {resource.name}
+                      <Image
+                        src="/assets/design-vectors/dropdown-arrow.svg"
+                        alt="Dropdown icon"
+                        width={18}
+                        height={18}
+                        className={styles.dropdownIcon}
+                      />
+                    </button>
+                    {openIndex === index && (
+                      <div className={styles.dropdownContent}>
+                        <p>{resource.description}</p>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <div className={styles.academicContainer}>
+                <h3>Academic</h3>
+                {resourcesData[1].items.map((resource, index) => (
+                  <div key={index} className={styles.resourceItem}>
+                    <button
+                      type="button"
+                      onClick={
+                        () =>
+                          toggleDropdown(index + resourcesData[0].items.length)
+                        // eslint-disable-next-line react/jsx-curly-newline
+                      }
+                      className={`${styles.resourceName} ${openIndex === index + resourcesData[0].items.length ? styles.open : ''}`}
+                    >
+                      {resource.name}
+                      <Image
+                        src="/assets/design-vectors/dropdown-arrow.svg"
+                        alt="Dropdown icon"
+                        width={18}
+                        height={18}
+                        className={styles.dropdownIcon}
+                      />
+                    </button>
+                    {openIndex === index + resourcesData[0].items.length && (
+                      <div className={styles.dropdownContent}>
+                        <p>{resource.description}</p>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <div className={styles.otherContainer}>
+                <h3>Other</h3>
+                {resourcesData[2].items.map((resource, index) => (
+                  <div key={index} className={styles.resourceItem}>
+                    <button
+                      type="button"
+                      onClick={
+                        () =>
+                          toggleDropdown(
+                            // eslint-disable-next-line react/jsx-curly-newline
+                            index +
+                              resourcesData[0].items.length +
+                              resourcesData[1].items.length,
+                          ) // eslint-disable-next-line react/jsx-curly-newline
+                      }
+                      className={`${styles.resourceName} 
+                  ${openIndex === index + resourcesData[0].items.length + resourcesData[1].items.length ? styles.open : ''}`}
+                    >
+                      {resource.name}
+                      <Image
+                        src="/assets/design-vectors/dropdown-arrow.svg"
+                        alt="Dropdown icon"
+                        width={18}
+                        height={18}
+                        className={styles.dropdownIcon}
+                      />
+                    </button>
+                    {openIndex ===
+                      // eslint-disable-next-line react/jsx-indent
+                      index +
+                        resourcesData[0].items.length +
+                        resourcesData[1].items.length && (
+                      // eslint-disable-next-line react/jsx-indent
+                      <div className={styles.dropdownContent}>
+                        <p>{resource.description}</p>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </ComputerWindow>
+        </div>
+      </DesktopContainer>
+      <MobileContainer>
+        <div className={styles.window}>
+          <ComputerWindow topbarColor="wcs-pink" showButtons={false}>
+            <div className={styles.container}>{renderContainer(0)}</div>
+          </ComputerWindow>
+        </div>
+      </MobileContainer>
+    </>
   );
 }

--- a/src/sections/GetHelpSection.js
+++ b/src/sections/GetHelpSection.js
@@ -25,6 +25,22 @@ export default function GetHelpSection() {
       return (
         <div className={styles.mentalhContainer}>
           <div className={styles.containerHeader}>
+            <button
+              type="button"
+              onClick={() => setContainerIndex(1)}
+              className={styles.changeContainer}
+            >
+              <Image
+                src="/assets/design-vectors/dropdown-arrow.svg"
+                alt="Dropdown icon"
+                width={18}
+                height={18}
+                className={styles.dropdownIcon}
+                style={{
+                  visibility: 'hidden',
+                }}
+              />
+            </button>
             <h3>Mental Health</h3>
             <button
               type="button"
@@ -158,6 +174,22 @@ export default function GetHelpSection() {
             />
           </button>
           <h3>Other</h3>
+          <button
+            type="button"
+            onClick={() => setContainerIndex(1)}
+            className={styles.changeContainer}
+          >
+            <Image
+              src="/assets/design-vectors/dropdown-arrow.svg"
+              alt="Dropdown icon"
+              width={18}
+              height={18}
+              className={styles.dropdownIcon}
+              style={{
+                visibility: 'hidden',
+              }}
+            />
+          </button>
         </div>
         {resourcesData[2].items.map((resource, index) => (
           <div key={index} className={styles.resourceItem}>

--- a/src/styles/sections/GetHelpSection.module.css
+++ b/src/styles/sections/GetHelpSection.module.css
@@ -25,6 +25,14 @@
   word-break: break-word;
 }
 
+.desktop {
+  display: block;
+}
+
+.mobile {
+  display: none;
+}
+
 .mentalhContainer {
   border-left: 10px;
   border-color: var(--light-pink);
@@ -61,6 +69,13 @@
   justify-content: space-between;
 }
 
+.changeContainer {
+  border: none;
+  background: none;
+  cursor: pointer;
+  margin: 0 1rem;
+}
+
 .resourceName:hover {
   color: var(--wcs-pink);
 }
@@ -84,4 +99,29 @@
 .resourceName:hover .dropdownIcon {
   filter: brightness(0) saturate(100%) invert(47%) sepia(57%) saturate(350%)
     hue-rotate(290deg) brightness(90%) contrast(95%);
+}
+
+.containerHeader {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.containerHeader h3 {
+  margin: 0;
+}
+
+@media (max-width: 1152px) {
+  .desktop {
+    display: none;
+  }
+
+  .mobile {
+    display: block;
+  }
+
+  .container {
+    display: flex;
+    flex-direction: row;
+    width: fit-content;
+  }
 }

--- a/src/styles/sections/GetHelpSection.module.css
+++ b/src/styles/sections/GetHelpSection.module.css
@@ -103,11 +103,14 @@
 
 .containerHeader {
   display: flex;
-  gap: 0.5rem;
+  justify-content: space-between;
+  width: 120%;
+  align-self: center;
 }
 
 .containerHeader h3 {
   margin: 0;
+  text-align: center;
 }
 
 @media (max-width: 1152px) {


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready


## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

<!-- Addresses #<number> -->

- Created Desktop and Mobile containers
- Only displays one section on mobile
- Use chevron buttons to switch between individual sections

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
<img width="304" alt="Screenshot 2025-04-01 at 6 20 17 PM" src="https://github.com/user-attachments/assets/955dc058-ea0b-4b5a-91df-ac878af3f332" />
<img width="297" alt="Screenshot 2025-04-01 at 6 20 13 PM" src="https://github.com/user-attachments/assets/e2f0c911-4c6c-415c-ae49-fc4dc67ae514" />
<img width="305" alt="Screenshot 2025-04-01 at 6 20 09 PM" src="https://github.com/user-attachments/assets/28f46f80-1483-4b4f-a8f5-5ae7d4e81998" />

