### PR TITLE
center modal buttons relative to their containers

### DIFF
--- a/src/styles/pages/Home.module.css
+++ b/src/styles/pages/Home.module.css
@@ -231,6 +231,7 @@
   border-radius: 10px;
   background-color: var(--light-pink);
   position: relative;
+  margin: 0 auto;
 }
 
 .modalButton p {


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

<!-- Addresses #<number> -->

- the buttons are centered, but idk if it looks weird bc the text is all left-aligned?

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
<img width="786" alt="Screenshot 2025-04-06 at 1 41 27 PM" src="https://github.com/user-attachments/assets/b62c4ffb-e4de-4bdf-a44d-a70ff117a2bc" />

