### PR TITLE
Change Computer Window Button Colors

### DIFF
--- a/src/styles/components/ComputerWindow.module.css
+++ b/src/styles/components/ComputerWindow.module.css
@@ -37,12 +37,12 @@
 }
 
 .topbarGreenButton {
-  background-color: lime;
+  background-color: #62c755;
   left: 2.5rem;
 }
 
 .topbarRedButton {
-  background-color: red;
+  background-color: #ed6a5e;
   width: 0.5rem;
   height: 0.5rem;
   border: none;
@@ -52,6 +52,6 @@
 }
 
 .topbarYellowButton {
-  background-color: yellow;
+  background-color: #f5bf4f;
   left: 1.5rem;
 }


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->
:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits. If applicable, link the PR to the corresponding issue below by filling out the number.
-->

<!-- Addresses #<number> -->

- change button colors to mac colors

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
Before:
<img width="74" alt="Screenshot 2025-04-07 at 3 12 58 PM" src="https://github.com/user-attachments/assets/6ab47200-c37a-444d-80cf-4c7854428676" />
After:
<img width="69" alt="Screenshot 2025-04-07 at 3 13 39 PM" src="https://github.com/user-attachments/assets/64632c53-056c-4c70-8af0-e2fb4eb65a06" />

One concern is that the red is hard to see on the wcs pink:
<img width="70" alt="Screenshot 2025-04-07 at 3 13 42 PM" src="https://github.com/user-attachments/assets/6b77f5d6-2561-4610-95b5-530122142655" />



