### PR TITLE
changed font color to black 0.6

### DIFF
--- a/src/styles/components/EventDescriptionModal.module.css
+++ b/src/styles/components/EventDescriptionModal.module.css
@@ -63,6 +63,7 @@
 }
 
 .description {
+  color: rgba(10, 10, 10, 0.6);
   font-weight: 400;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
The font of the event modals is now 0.6 opacity black.
-->

<!-- Addresses #<number> -->

Addresses: <(link notion task here)>

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
