### PR TITLE
Ordering the questions and answers

### DIFF
--- a/src/server/server.mjs
+++ b/src/server/server.mjs
@@ -69,6 +69,8 @@ async function getQuestionsAndAnswers(databaseId) {
   while (true) {
     const resp = await qaForumNotion.databases.query({
       database_id: databaseId,
+      //sorting the questions from newest to oldest
+      sorts: [{property: 'Timestamp', direction: 'descending' }],
       ...(startCursor ? { start_cursor: startCursor } : {}),
     });
     allPages = allPages.concat(resp.results || []);
@@ -119,6 +121,7 @@ async function getQuestionsAndAnswers(databaseId) {
   // attach answers to each questions at end
   questions.forEach((q) => {
     const list = answers[q.QuestionID] || [];
+    list.sort((a, b) => new Date(a.Timestamp) - new Date(b.Timestamp));
     q.Answers = list;
   });
 


### PR DESCRIPTION
Changing the order of the questions and answers within the server

- Questions are sorted from newest to oldest by modifying the notion query to get questions
- Answers for each question are sorted from oldest to newest by sorting the list retrieved from the notion database